### PR TITLE
Using AJAX to fetch the links.json file

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,16 +1,31 @@
-import socialLinks from '../assets/links.json' with {type: 'json'}
-
-let obj = Object.keys(socialLinks)
-let section = document.querySelector("section")
-for (let i = 0; i < obj.length; i++){
-    let social = document.createElement("div")
-    function redirect(){
-        social.style.background = '#fff'
-        social.style.color = '#282828'
-        open(`${socialLinks[obj[i]]}`)
-    }
-    social.setAttribute('class',`social`)
-    social.onclick = redirect
-    social.innerHTML = obj[i]
-    section.appendChild(social)
+function renderSocialLinks(socialLinks) {
+	let obj = Object.keys(socialLinks)
+	let section = document.querySelector("section")
+	for (let i = 0; i < obj.length; i++){
+		let social = document.createElement("div")
+		function redirect(){
+			social.style.background = '#fff'
+			social.style.color = '#282828'
+			open(`${socialLinks[obj[i]]}`)
+		}
+		social.setAttribute('class',`social`)
+		social.onclick = redirect
+		social.innerHTML = obj[i]
+		section.appendChild(social)
+	}
 }
+
+const xhr = new XMLHttpRequest()
+
+// after the request was completed, it will parse the json and load the content normally
+
+xhr.onload = () => {
+	const socialLinks = JSON.parse(xhr.response)
+	renderSocialLinks(socialLinks)
+
+}
+
+// send a get request to the links.json file
+
+xhr.open("GET", "/links/assets/links.json")
+xhr.send()


### PR DESCRIPTION
Now using AJAX to fetch the `links.json` file instead of depending on the `import assert` syntax to fetch the JSON automatically, which doesn't works on Firefox and some other browsers by default.

## Side notes

I had some problems when trying to make this work on the Github Pages because, when dealing with JS modules, the path that your application is will be the root of your repo -- `https://kevinmarquesp.github.io/links` on my case.

So, when you try to fetch the `../assets/links.json` file it will look for this file in `https://kevinmarquesp.github.io/assets/links.json` because the `..` is pointing outside your repo location. I fixed this by fetching the file in `/links/assets/links.json` specifically.

### Possible problems with this approach

The only problem is that you need to pay attention on the repo name, if you want to change the repo to `contact`, for an example, you'll need to update the `js/index.js` file to fetch the `links.json` in `/contact/assets/links.json`.

Another case that you may want to consider, is that if the name of of the `links.json` name changes or the browser of the user could not fetch this file via AJAX, maybe because a weird network issue. You can add a case to check if the status code is `404`, or some other error status code, and then render a *"Não foi possível carregar a página"* message or something like that.